### PR TITLE
Update to shim 15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,16 @@ RUN dnf install -y \
     gcc \
     git \
     gnu-efi-devel \
-    make
+    make \
+    patch
 
-# Clone shim, check out version 15
-RUN git clone --branch 15 https://github.com/rhboot/shim.git /build/shim
+# Clone shim, check out tag shim-15.1
+RUN git clone --branch shim-15.1 https://github.com/rhboot/shim.git /build/shim
 WORKDIR /build/shim
+
+# Apply a patch to fix compilation
+ADD build-fix.patch .
+RUN patch -p1 -i build-fix.patch
 
 # Add our public certificate
 ADD neverware.cer .

--- a/build-fix.patch
+++ b/build-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/mok.c b/mok.c
+index 2216e98..afee969 100644
+--- a/mok.c
++++ b/mok.c
+@@ -323,6 +323,7 @@ maybe_mirror_one_mok_variable(struct mok_state_variable *v, EFI_STATUS ret)
+ 				ret = efi_status;
+ 			perror(L"Could not create %s: %r\n", v->rtname,
+ 			       efi_status);
++		}
+ 	}
+ 	return ret;
+ }


### PR DESCRIPTION
This upstream tag does not build, so I added a small patch in
`build-fix.patch` that gets applied after cloning the repo.

Note that we are still building with a Fedora 28 container. I tried
updating to newer versions, but the shim build fails on all newer
versions I tried. Some of these errors have likely been fixed in the
past two years of shim development, but there haven't been any
official releases of that code.

https://neverware.atlassian.net/browse/OVER-12692