### PR TITLE
Add SBAT data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN git submodule update --init
 # Add our public certificate
 ADD neverware.cer .
 
+# Add our SBAT data
+ADD sbat.csv data/sbat.csv
+
 # Create build directories
 RUN mkdir build-x64 build-ia32
 

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,8 @@ copy:
 cert-info:
 	openssl x509 -inform der -in neverware.cer -noout -text
 
-.PHONY: build build-no-cache cert-info copy
+# Dump ".sbat" section of the builds
+dump-sbat:
+	objdump -j .sbat -s install/*
+
+.PHONY: build build-no-cache cert-info copy dump-sbat

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Copy the shim builds from the container to the host:
 View details of the public certificate:
 
     make cert-info
+
+View SBAT section of the shim binaries:
+
+    make dump-sbat

--- a/sbat.csv
+++ b/sbat.csv
@@ -1,0 +1,3 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+shim,1,UEFI shim,shim,1,https://github.com/rhboot/shim
+shim.cloudready,1,CloudReady,shim,15.4,https://github.com/neverware/shim-build


### PR DESCRIPTION
The data is in `sbat.csv`. It gets picked up during the build by
copying it (in the docker build) to `data/sbat.csv` in the shim source
checkout.

Also added a `make dump-sbat` target to help verify that the data is
correct.

Upstream documentation:
- https://github.com/rhboot/shim/blob/main/SBAT.md
- https://github.com/rhboot/shim/blob/main/SBAT.example.md

BUG=b:183954427