### PR TITLE
Build shim 15.4 from tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
 FROM fedora:33
 
 RUN dnf install -y \
+    bzip2 \
     gcc \
     git \
     gnu-efi-devel \
     make \
-    patch
+    patch \
+    wget
+
+# pnardini: We need to build shim 15.4 from a tarball.  Download and extract it.
+RUN mkdir -p /build/shim
+WORKDIR /build/shim
+RUN wget https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
+RUN tar -jxvpf shim-15.4.tar.bz2 && rm shim-15.4.tar.bz2
+WORKDIR /build/shim/shim-15.4
+
+# pnardini: The below section has been commented out for shim 15.4.  Not sure if
+# this is a one-off or if tarballs will be how we build shim going forward, so
+# leaving this section here for now.
 
 # Clone shim, check out tag 15.4, and init submodules
-RUN git clone --branch 15.4 https://github.com/rhboot/shim.git /build/shim
-WORKDIR /build/shim
-RUN git submodule update --init
+# RUN git clone --branch 15.4 https://github.com/rhboot/shim.git /build/shim
+# WORKDIR /build/shim
+# RUN git submodule update --init
 
 # Add our public certificate
 ADD neverware.cer .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,12 @@ RUN dnf install -y \
     patch \
     wget
 
-# pnardini: We need to build shim 15.4 from a tarball.  Download and extract it.
+# pnardini: We need to build shim 15.4 from a tarball now.  Download and extract it.
 RUN mkdir -p /build/shim
 WORKDIR /build/shim
 RUN wget https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
 RUN tar -jxvpf shim-15.4.tar.bz2 && rm shim-15.4.tar.bz2
 WORKDIR /build/shim/shim-15.4
-
-# pnardini: The below section has been commented out for shim 15.4.  Not sure if
-# this is a one-off or if tarballs will be how we build shim going forward, so
-# leaving this section here for now.
-
-# Clone shim, check out tag 15.4, and init submodules
-# RUN git clone --branch 15.4 https://github.com/rhboot/shim.git /build/shim
-# WORKDIR /build/shim
-# RUN git submodule update --init
 
 # Add our public certificate
 ADD neverware.cer .


### PR DESCRIPTION
For shim 15.4 upstream review requires that we build from a tarball
(https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2)
rather than the git tag.  The most obvious reason for this seems to be
that the tarball contains required gnu-efi files, while the tag does
not.  The original git clone commands have been left in the Dockerfile
to revert to should future submissions to back to the tag-based builds.