### PR TITLE
Patching critical shim 15.4 regressions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,35 @@ RUN dnf install -y \
     patch \
     wget
 
-# pnardini: We need to build shim 15.4 from a tarball now.  Download and extract it.
+# pnardini: We need to build shim 15.4 from a tarball now.
+# Download and extract it.
 RUN mkdir -p /build/shim
 WORKDIR /build/shim
 RUN wget https://github.com/rhboot/shim/releases/download/15.4/shim-15.4.tar.bz2
 RUN tar -jxvpf shim-15.4.tar.bz2 && rm shim-15.4.tar.bz2
 WORKDIR /build/shim/shim-15.4
+
+# Add patches for critical shim 15.4 regressions.
+# See https://github.com/rhboot/shim-review/issues/165
+#
+# Note:  We are not pulling in https://github.com/rhboot/shim/pull/366.
+# We do not need to support ARM at this time.
+
+# https://github.com/rhboot/shim/pull/364
+ADD shim_15.4_8b59591_364.patch .
+RUN patch -p1 -i shim_15.4_8b59591_364.patch
+
+# https://github.com/rhboot/shim/pull/362
+ADD shim_15.4_975c2fe_362.patch .
+RUN patch -p1 -i shim_15.4_975c2fe_362.patch
+
+# https://github.com/rhboot/shim/pull/357
+ADD shim_15.4_1bea91b_357.patch .
+RUN patch -p1 -i shim_15.4_1bea91b_357.patch
+
+# https://github.com/rhboot/shim/pull/361
+ADD shim_15.4_33ca950_361.patch .
+RUN patch -p1 -i shim_15.4_33ca950_361.patch
 
 # Add our public certificate
 ADD neverware.cer .

--- a/shim_15.4_1bea91b_357.patch
+++ b/shim_15.4_1bea91b_357.patch
@@ -1,0 +1,12 @@
+diff --git a/elf_ia32_efi.lds b/elf_ia32_efi.lds
+index 742e0a47a..497a3a152 100644
+--- a/elf_ia32_efi.lds
++++ b/elf_ia32_efi.lds
+@@ -15,6 +15,7 @@ SECTIONS
+    *(.gnu.linkonce.t.*)
+    _etext = .;
+   }
++  . = ALIGN(4096);
+   .reloc :
+   {
+    *(.reloc)

--- a/shim_15.4_33ca950_361.patch
+++ b/shim_15.4_33ca950_361.patch
@@ -1,0 +1,13 @@
+diff --git a/mok.c b/mok.c
+index 5ad9072be..fc1ee04da 100644
+--- a/mok.c
++++ b/mok.c
+@@ -1002,7 +1002,7 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
+ 		npages = ALIGN_VALUE(config_sz, PAGE_SIZE) >> EFI_PAGE_SHIFT;
+ 		config_table = NULL;
+ 		efi_status = gBS->AllocatePages(AllocateAnyPages,
+-						EfiRuntimeServicesData,
++						EfiBootServicesData,
+ 						npages,
+ 						(EFI_PHYSICAL_ADDRESS *)&config_table);
+ 		if (EFI_ERROR(efi_status) || !config_table) {

--- a/shim_15.4_8b59591_364.patch
+++ b/shim_15.4_8b59591_364.patch
@@ -1,0 +1,41 @@
+diff --git a/mok.c b/mok.c
+index 9b8fc2bc..beac0ff6 100644
+--- a/mok.c
++++ b/mok.c
+@@ -261,6 +261,9 @@ static const uint8_t null_sha256[32] = { 0, };
+ 
+ typedef UINTN SIZE_T;
+ 
++#define EFI_MAJOR_VERSION(tablep) ((UINT16)((((tablep)->Hdr.Revision) >> 16) & 0xfffful))
++#define EFI_MINOR_VERSION(tablep) ((UINT16)(((tablep)->Hdr.Revision) & 0xfffful))
++
+ static EFI_STATUS
+ get_max_var_sz(UINT32 attrs, SIZE_T *max_var_szp)
+ {
+@@ -270,11 +273,21 @@ get_max_var_sz(UINT32 attrs, SIZE_T *max_var_szp)
+ 	uint64_t max_var_sz = 0;
+ 
+ 	*max_var_szp = 0;
+-	efi_status = gRT->QueryVariableInfo(attrs, &max_storage_sz,
+-					    &remaining_sz, &max_var_sz);
+-	if (EFI_ERROR(efi_status)) {
+-		perror(L"Could not get variable storage info: %r\n", efi_status);
+-		return efi_status;
++	if (EFI_MAJOR_VERSION(gRT) < 2) {
++		dprint(L"EFI %d.%d; no RT->QueryVariableInfo().  Using 1024!\n",
++		       EFI_MAJOR_VERSION(gRT), EFI_MINOR_VERSION(gRT));
++		max_var_sz = remaining_sz = max_storage_sz = 1024;
++		efi_status = EFI_SUCCESS;
++	} else {
++		dprint(L"calling RT->QueryVariableInfo() at 0x%lx\n",
++		       gRT->QueryVariableInfo);
++		efi_status = gRT->QueryVariableInfo(attrs, &max_storage_sz,
++						    &remaining_sz, &max_var_sz);
++		if (EFI_ERROR(efi_status)) {
++			perror(L"Could not get variable storage info: %r\n",
++			       efi_status);
++			return efi_status;
++		}
+ 	}
+ 
+ 	/*

--- a/shim_15.4_975c2fe_362.patch
+++ b/shim_15.4_975c2fe_362.patch
@@ -1,0 +1,14 @@
+diff --git a/mok.c b/mok.c
+index 5ad9072be..9e37d6ab5 100644
+--- a/mok.c
++++ b/mok.c
+@@ -888,9 +888,6 @@ EFI_STATUS import_one_mok_state(struct mok_state_variable *v,
+ 	EFI_STATUS ret = EFI_SUCCESS;
+ 	EFI_STATUS efi_status;
+ 
+-	user_insecure_mode = 0;
+-	ignore_db = 0;
+-
+ 	UINT32 attrs = 0;
+ 	BOOLEAN delete = FALSE;
+ 


### PR DESCRIPTION
Apply patch files generated from the list of critical regressions
found at https://github.com/rhboot/shim-review/issues/165 to our
shim 15.4 build.  We generated a patch file for ARM support and
include it here, but do not apply it as it is not required yet.